### PR TITLE
v0.1.1

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -1,6 +1,6 @@
 /**
  * package: nodamysql
- * version:  0.1.0
+ * version:  0.1.1
  * author:  Richard B. Winters <a href="mailto:rik@mmogp.com">rik At MassivelyModified</a>
  * copyright: 2013-2014 Massively Modified, Inc.
  * license: Apache, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>

--- a/driver.h
+++ b/driver.h
@@ -1,6 +1,6 @@
 /**
  * package: nodamysql
- * version:  0.1.0
+ * version:  0.1.1
  * author:  Richard B. Winters <a href="mailto:rik@mmogp.com">rik At MassivelyModified</a>
  * copyright: 2013-2014 Massively Modified, Inc.
  * license: Apache, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>

--- a/includables/buildage/lin/binding_config.h
+++ b/includables/buildage/lin/binding_config.h
@@ -1,0 +1,36 @@
+/*
+   Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+
+   The MySQL Connector/C++ is licensed under the terms of the GPLv2
+   <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most
+   MySQL Connectors. There are special exceptions to the terms and
+   conditions of the GPL as it is applied to this software, see the
+   FLOSS License Exception
+   <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+
+#define HAVE_DLFCN_H 1
+/* #undef MYSQLCLIENT_STATIC_BINDING 1 */
+
+
+#if !defined(_WIN32) && !defined(HAVE_DLFCN_H) && !defined(MYSQLCLIENT_STATIC_BINDING)
+# define MYSQLCLIENT_STATIC_BINDING 1
+#endif
+
+#ifdef HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif

--- a/includables/buildage/lin/build_config.h
+++ b/includables/buildage/lin/build_config.h
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+
+The MySQL Connector/C++ is licensed under the terms of the GPLv2
+<http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most
+MySQL Connectors. There are special exceptions to the terms and
+conditions of the GPLv2 as it is applied to this software, see the
+FLOSS License Exception
+<http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+
+
+#ifndef _SQL_BUILD_CONFIG_H_
+#define _SQL_BUILD_CONFIG_H_
+
+#ifndef CPPCONN_PUBLIC_FUNC
+
+#if defined(_WIN32)
+ // mysqlcppconn_EXPORTS is added by cmake and defined for dynamic lib build only
+  #ifdef mysqlcppconn_EXPORTS
+    #define CPPCONN_PUBLIC_FUNC __declspec(dllexport)
+  #else
+    // this is for static build
+    #ifdef CPPCONN_LIB_BUILD
+      #define CPPCONN_PUBLIC_FUNC
+    #else
+      // this is for clients using dynamic lib
+      #define CPPCONN_PUBLIC_FUNC __declspec(dllimport)
+    #endif
+  #endif
+#else
+  #define CPPCONN_PUBLIC_FUNC
+#endif
+
+#endif    //#ifndef CPPCONN_PUBLIC_FUNC
+
+#endif    //#ifndef _SQL_BUILD_CONFIG_H_

--- a/includables/buildage/lin/config.h
+++ b/includables/buildage/lin/config.h
@@ -1,0 +1,110 @@
+/*
+   Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+
+   The MySQL Connector/C++ is licensed under the terms of the GPLv2
+   <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most
+   MySQL Connectors. There are special exceptions to the terms and
+   conditions of the GPL as it is applied to this software, see the
+   FLOSS License Exception
+   <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+// libmysql defines HAVE_STRTOUL (on win), so we have to follow different pattern in definitions names
+// to avoid annoying warnings.
+
+#define HAVE_FUNCTION_STRTOLD 1
+#define HAVE_FUNCTION_STRTOLL 1
+#define HAVE_FUNCTION_STRTOL 1
+#define HAVE_FUNCTION_STRTOULL 1
+
+#define HAVE_FUNCTION_STRTOUL 1
+
+#define HAVE_FUNCTION_STRTOIMAX 1
+#define HAVE_FUNCTION_STRTOUMAX 1
+
+#define HAVE_STDINT_H 1
+#define HAVE_INTTYPES_H 1
+
+#define HAVE_INT8_T   1
+#define HAVE_UINT8_T  1
+#define HAVE_INT16_T  1
+#define HAVE_UINT16_T 1
+#define HAVE_INT32_T  1
+#define HAVE_UINT32_T 1
+#define HAVE_INT32_T  1
+#define HAVE_UINT32_T 1
+#define HAVE_INT64_T  1
+#define HAVE_UINT64_T 1
+/* #undef HAVE_MS_INT8 */
+/* #undef HAVE_MS_UINT8 */
+/* #undef HAVE_MS_INT16 */
+/* #undef HAVE_MS_UINT16 */
+/* #undef HAVE_MS_INT32 */
+/* #undef HAVE_MS_UINT32 */
+/* #undef HAVE_MS_INT64 */
+/* #undef HAVE_MS_UINT64 */
+
+
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+
+#ifdef HAVE_INTTYPES_H
+#include <inttypes.h>
+#endif
+
+#if defined(_WIN32)
+#ifndef CPPCONN_DONT_TYPEDEF_MS_TYPES_TO_C99_TYPES
+
+#if _MSC_VER >= 1600
+
+#include <stdint.h>
+
+#else
+
+#if !defined(HAVE_INT8_T) && defined(HAVE_MS_INT8)
+typedef __int8			int8_t;
+#endif
+
+#ifdef HAVE_MS_UINT8
+typedef unsigned __int8	uint8_t;
+#endif
+#ifdef HAVE_MS_INT16
+typedef __int16			int16_t;
+#endif
+
+#ifdef HAVE_MS_UINT16
+typedef unsigned __int16	uint16_t;
+#endif
+
+#ifdef HAVE_MS_INT32
+typedef __int32			int32_t;
+#endif
+
+#ifdef HAVE_MS_UINT32
+typedef unsigned __int32	uint32_t;
+#endif
+
+#ifdef HAVE_MS_INT64
+typedef __int64			int64_t;
+#endif
+#ifdef HAVE_MS_UINT64
+typedef unsigned __int64	uint64_t;
+#endif
+
+#endif  // _MSC_VER >= 1600
+#endif	// CPPCONN_DONT_TYPEDEF_MS_TYPES_TO_C99_TYPES
+#endif	//	_WIN32

--- a/includables/buildage/win/binding_config.h
+++ b/includables/buildage/win/binding_config.h
@@ -1,0 +1,35 @@
+/*
+   Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+
+   The MySQL Connector/C++ is licensed under the terms of the GPLv2
+   <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most
+   MySQL Connectors. There are special exceptions to the terms and
+   conditions of the GPL as it is applied to this software, see the
+   FLOSS License Exception
+   <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+
+/* #undef HAVE_DLFCN_H */
+/* #undef MYSQLCLIENT_STATIC_BINDING */
+
+#if !defined(_WIN32) && !defined(HAVE_DLFCN_H) && !defined(MYSQLCLIENT_STATIC_BINDING)
+# define MYSQLCLIENT_STATIC_BINDING 1
+#endif
+
+#ifdef HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif

--- a/includables/buildage/win/build_config.h
+++ b/includables/buildage/win/build_config.h
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+
+The MySQL Connector/C++ is licensed under the terms of the GPLv2
+<http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most
+MySQL Connectors. There are special exceptions to the terms and
+conditions of the GPLv2 as it is applied to this software, see the
+FLOSS License Exception
+<http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published
+by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+
+
+#ifndef _SQL_BUILD_CONFIG_H_
+#define _SQL_BUILD_CONFIG_H_
+
+#ifndef CPPCONN_PUBLIC_FUNC
+
+#if defined(_WIN32)
+ // mysqlcppconn_EXPORTS is added by cmake and defined for dynamic lib build only
+  #ifdef mysqlcppconn_EXPORTS
+    #define CPPCONN_PUBLIC_FUNC __declspec(dllexport)
+  #else
+    // this is for static build
+    #ifdef CPPCONN_LIB_BUILD
+      #define CPPCONN_PUBLIC_FUNC
+    #else
+      // this is for clients using dynamic lib
+      #define CPPCONN_PUBLIC_FUNC __declspec(dllimport)
+    #endif
+  #endif
+#else
+  #define CPPCONN_PUBLIC_FUNC
+#endif
+
+#endif    //#ifndef CPPCONN_PUBLIC_FUNC
+
+#endif    //#ifndef _SQL_BUILD_CONFIG_H_

--- a/includables/buildage/win/config.h
+++ b/includables/buildage/win/config.h
@@ -1,0 +1,103 @@
+/*
+   Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+
+   The MySQL Connector/C++ is licensed under the terms of the GPLv2
+   <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most
+   MySQL Connectors. There are special exceptions to the terms and
+   conditions of the GPL as it is applied to this software, see the
+   FLOSS License Exception
+   <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published
+   by the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License along
+   with this program; if not, write to the Free Software Foundation, Inc.,
+   51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+// libmysql defines HAVE_STRTOUL (on win), so we have to follow different pattern in definitions names
+// to avoid annoying warnings.
+
+#define HAVE_FUNCTION_STRTOLD 1
+#define HAVE_FUNCTION_STRTOLL 1
+#define HAVE_FUNCTION_STRTOL 1
+#define HAVE_FUNCTION_STRTOULL 1
+
+#define HAVE_FUNCTION_STRTOUL 1
+
+#define HAVE_FUNCTION_STRTOIMAX 1
+#define HAVE_FUNCTION_STRTOUMAX 1
+
+#define HAVE_STDINT_H 1
+
+#define HAVE_MS_INT8     1
+#define HAVE_MS_UINT8    1
+#define HAVE_MS_INT16    1
+#define HAVE_MS_UINT16   1
+#define HAVE_MS_INT32    1
+#define HAVE_MS_UINT32   1
+#define HAVE_MS_INT64   1
+#define HAVE_MS_UINT64   1
+
+
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+
+#ifdef HAVE_INTTYPES_H
+#include <inttypes.h>
+#endif
+
+#if defined(_WIN32)
+#ifndef CPPCONN_DONT_TYPEDEF_MS_TYPES_TO_C99_TYPES
+
+#if _MSC_VER >= 1600
+
+#include <stdint.h>
+
+#else
+
+#if !defined(HAVE_INT8_T) && defined(HAVE_MS_INT8)
+typedef __int8			int8_t;
+#endif
+
+#ifdef HAVE_MS_UINT8
+typedef unsigned __int8	uint8_t;
+#endif
+#ifdef HAVE_MS_INT16
+typedef __int16			int16_t;
+#endif
+
+#ifdef HAVE_MS_UINT16
+typedef unsigned __int16	uint16_t;
+#endif
+
+#ifdef HAVE_MS_INT32
+typedef __int32			int32_t;
+#endif
+
+#ifdef HAVE_MS_UINT32
+typedef unsigned __int32	uint32_t;
+#endif
+
+#ifdef HAVE_MS_INT64
+typedef __int64			int64_t;
+#endif
+#ifdef HAVE_MS_UINT64
+typedef unsigned __int64	uint64_t;
+#endif
+
+#endif  // _MSC_VER >= 1600
+#endif	// CPPCONN_DONT_TYPEDEF_MS_TYPES_TO_C99_TYPES
+#endif	//	_WIN32
+
+#ifdef BUILD_SHARED
+#define dllimport dllexport
+#endif

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /**
  * package: nodamysql
- * version:  0.1.0
+ * version:  0.1.1
  * author:  Richard B. Winters <a href="mailto:rik@massivelymodified.com">rik At MMOGP</a>
  * copyright: 2011-2014 Massively Modified, Inc.
  * license: Apache, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>

--- a/library/mysql/connectorc++/binding.gyp
+++ b/library/mysql/connectorc++/binding.gyp
@@ -128,7 +128,7 @@
 						'copies':
 						[
 							{
-								'files': [ '../../../includables/build/win/build_config.h', '../../../includables/build/win/config.h' ],
+								'files': [ '../../../includables/buildage/win/build_config.h', '../../../includables/buildage/win/config.h' ],
 								'destination': './cppconn/'
 							}
 						]
@@ -139,7 +139,7 @@
 						'copies':
 						[
 							{
-								'files': [ '../../../includables/build/win/binding_config.h' ],
+								'files': [ '../../../includables/buildage/win/binding_config.h' ],
 								'destination': './driver/nativeapi/'
 							}
 						]
@@ -196,7 +196,7 @@
 						'copies':
 						[
 							{
-								'files': [ '../../../includables/build/lin/build_config.h', '../../../includables/build/lin/config.h' ],
+								'files': [ '../../../includables/buildage/lin/build_config.h', '../../../includables/buildage/lin/config.h' ],
 								'destination': 'cppconn/'
 							}
 						]
@@ -207,7 +207,7 @@
 						'copies':
 						[
 							{
-								'files': [ '../../../includables/build/lin/binding_config.h' ],
+								'files': [ '../../../includables/buildage/lin/binding_config.h' ],
 								'destination': 'driver/nativeapi/'
 							}
 						]

--- a/nodamysql.cpp
+++ b/nodamysql.cpp
@@ -1,6 +1,6 @@
 /**
  * package: nodamysql
- * version:  0.1.0
+ * version:  0.1.1
  * author:  Richard B. Winters <a href="mailto:rik@mmogp.com">rik At MassivelyModified</a>
  * copyright: 2013-2014 Massively Modified, Inc.
  * license: Apache, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nk-mysql",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A mostly simple, yet powerful C++ data integration toolset for nodakwaeri (nk) or any application which would make use of it.  Featuring the MySQL C++ Connector from Oracle, designed to keep your application secure and efficient.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- The build folder in includables was being ignored, and so the input
  files required by the build process were not present and the install was
  failing.  The name of the directory is now buildage, the bindings file
  has been updated, and the build process is completing.

Change-Id: Ifd23b2c785f7428613b72655ecba23bafdd605e2
Signed-off-by: Richard Winters rik@mmogp.com
