### PR TITLE
0.2.x (0.2.2) Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 # Build directories in root
 build
 node_modules
+/npm-debug.log

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are a few  prerequisites that need to be in place in order to properly bui
 To install (installing is how we build too!); open a terminal/shell/command tools/prompt and browse to the root of your application. Run the following command:
 
 ```
-path_to_application/> npm install nk-mysql@0.2.x
+path_to_application/> npm install nk-mysql@node-v10
 ```
 
 If you are building, you should have no problems (If you verified that all of the prerequisites are met) and other than some potential warnings everything will build properly.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are a few  prerequisites that need to be in place in order to properly bui
 To install (installing is how we build too!); open a terminal/shell/command tools/prompt and browse to the root of your application. Run the following command:
 
 ```
-path_to_application/> npm install nk-mysql@0.2.1
+path_to_application/> npm install nk-mysql@0.2.x
 ```
 
 If you are building, you should have no problems (If you verified that all of the prerequisites are met) and other than some potential warnings everything will build properly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nk-mysql",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A mostly simple, yet powerful C++ data integration toolset for nodakwaeri (nk) or any application which would make use of it.  Featuring the MySQL C++ Connector from Oracle, designed to keep your application secure and efficient.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### Updates
***

- Updated .gitignore to ignore npm-debug.log
- Updated README.md as to include proper instructions for installing the
tagged version of nk-mysql; the new tag is node-v10
- Updated tag name in installation steps, since using semver string is
not allowed.
- Bumped version to 0.2.2 so since we cannot modify existing versions.
Version bump necessary to keep 0.2.x branch alive and to also keep it
'non-default'.  We want 0.4.x to install via the 'latest' tag.